### PR TITLE
:bug: Fix invalid JSON

### DIFF
--- a/AutoLayoutPlugin.sketchplugin/Contents/Sketch/manifest.json
+++ b/AutoLayoutPlugin.sketchplugin/Contents/Sketch/manifest.json
@@ -82,7 +82,7 @@
                    "com.animaapp.check-for-update",
                    "com.animaapp.changelog",
                    "com.animaapp.open-community"
-                   ],
+                   ]
     },
     "identifier" : "com.animaapp.stc-sketch-plugin",
     "description": "Auto Layout for Sketch",


### PR DESCRIPTION
Fixes the parse error exposed by [JSON Lint](http://jsonlint.com/)

```
Error: Parse error on line 75:
...en-community"		],	},	"identifier": "c
---------------------^
Expecting 'STRING', got '}'
```